### PR TITLE
iOS 13 layout on rotation

### DIFF
--- a/JDStatusBarNotification/JDStatusBarNotification.m
+++ b/JDStatusBarNotification/JDStatusBarNotification.m
@@ -522,7 +522,7 @@ static CGFloat topBarHeightAdjustedForIphoneX(JDStatusBarStyle *style, CGFloat h
 
 - (void)updateTopBarFrameWithStatusBarFrame:(CGRect)rect;
 {
-  CGFloat width = MAX(rect.size.width, rect.size.height);
+  CGFloat width = self.overlayWindow.rootViewController.view.frame.size.width;
   CGFloat height = MIN(rect.size.width, rect.size.height);
 
   // adjust position for iOS 7, if statusBar has double height


### PR DESCRIPTION
Fixes a bug where rotating from portrait to landscape and back to portrait would end up with a status bar notification that thought its new width was actually the height of the phone's screen, so stuff was pushed off to the right. This makes sure that it's limited to the screen's width.